### PR TITLE
adds stylesheet link

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 	<title>A Kick-Ass Webpack Configuration for React and SASS</title>
+	<link rel="stylesheet" type="text/css" href="public/style.css">
 </head>
 <body>
 	<div id="app"></div>


### PR DESCRIPTION
The [original post](https://www.jonathan-petitcolas.com/2015/05/15/howto-setup-webpack-on-es6-react-application-with-sass.html) mentions:

> Just include a link tag on your page, and your styles should still be here.

why not include it in this project to make it a bit clearer?