### PR TITLE
loader suffix

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,11 +22,11 @@ module.exports = {
     module: {
         loaders: [
             { 
-                test: /\.js$/, loaders: ['react-hot', 'jsx', 'babel'], exclude: /node_modules/ 
+                test: /\.js$/, loaders: ['react-hot-loader/webpack', 'jsx-loader', 'babel-loader'], exclude: /node_modules/ 
             },
             {
                 test: /\.scss$/,
-                loader: ExtractTextPlugin.extract('css!sass')
+                loader: ExtractTextPlugin.extract('css-loader!sass-loader')
             }
         ]
        },


### PR DESCRIPTION
Bonjour Jonathan, Thanks for your article on setting up Webpack. It's much better than the other resources I found. I used it for my own project. I was using more recent versions of the packages and things broke because the `-loader` suffix cannot be ommited anymore. These changes are not necessary in your repo since you're using older versions but maybe it will encourage you to update your article? It's still useful!